### PR TITLE
WIP: Add Domains endpoint

### DIFF
--- a/src/ipa-tuura/ipatuura/adapters.py
+++ b/src/ipa-tuura/ipatuura/adapters.py
@@ -7,7 +7,7 @@ import logging
 from django.contrib.auth.models import BaseUserManager
 from django.db import transaction
 
-from django_scim.adapters import SCIMGroup, SCIMUser
+from django_scim.adapters import SCIMGroup, SCIMUser, SCIMMixin
 from ipatuura.ipa import IPA
 
 
@@ -160,3 +160,7 @@ class SCIMGroup(SCIMGroup):
         Return the displayName of the group per the SCIM spec.
         """
         return self.obj.scim_display_name
+
+
+class DomainAdapter(SCIMMixin):
+    id_field = 'domain'

--- a/src/ipa-tuura/ipatuura/models.py
+++ b/src/ipa-tuura/ipatuura/models.py
@@ -320,3 +320,7 @@ class Group(AbstractSCIMGroupMixin):
         else:
             self._user_set = CustomGroupUserRelationManager()
             return self._user_set
+
+
+class Domain(models.Model):
+    domain = models.CharField(primary_key=True)

--- a/src/ipa-tuura/ipatuura/views.py
+++ b/src/ipa-tuura/ipatuura/views.py
@@ -2,6 +2,22 @@
 # Copyright (C) 2022  FreeIPA Contributors see COPYING for license
 #
 
-from django.shortcuts import render
+from django_scim.views import (
+    GetView,
+    PostView,
+    PutView,
+    PatchView,
+    DeleteView,
+    SCIMView
+)
 
-# Create your views here.
+from ipatuura.adapters import DomainAdapter
+from ipatuura.models import Domain
+
+
+class DomainsView(GetView, PostView, PutView, PatchView, DeleteView, SCIMView):
+
+    http_method_names = ['get', 'post', 'put', 'patch', 'delete']
+
+    scim_adapter_getter = DomainAdapter
+    model_cls_getter = Domain

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -18,10 +18,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from ipatuura import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('scim/v2/', include('django_scim.urls')),
     path('creds/', include('creds.urls')),
+    re_path(r'^scim/v2/Domains(?:/(?P<uuid>[^/]+))?$',
+            views.DomainsView.as_view(),
+            name='domains'),
 ]


### PR DESCRIPTION
`django-scim2` isn't super extensible like other general purpose REST frameworks, it's intended to support Users and Groups endpoints, to add others there's no built-in mechanism to register models and auto-generate the rest.

**Not tested yet.**