### PR TITLE
README: AD Trust setup addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ $ cd $IPA_TUURA/src/install
 $ python prepare_sssd.py
 ```
 
+.. note:
+   If resolving IPA - AD Trust users is required, the prepare_sssd.py script needs
+   to be run on IPA servers as well.
+
 ### Django preparation
 
 Create and activate a python virtual env


### PR DESCRIPTION
For AD trust users, extra attributes are retrieved only if the `ldap_user_extra_attrs` and `user_attributes` infopipe related lines are added to sssd.conf on the IPA server.