### PR TITLE
Enable ServiceProviderConfig GET request

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,18 @@ If connecting from another system, update the ALLOWED_HOSTS line `root/settings.
 ALLOWED_HOSTS = ['192.168.122.221', 'localhost', '127.0.0.1']
 ```
 
-And run the following to have django listen on all interfaces:
+as well as the NETLOC from SCIM_SERVICE_PROVIDER settings:
+
+```bash
+SCIM_SERVICE_PROVIDER = {
+    'NETLOC': 'localhost',
+...
+```
+and replace `localhost` by the IP address or hostname where the service is deployed. This way,
+the /ServiceProviderConfig endpoint will return the location of the app implementing the SCIM
+api.
+
+Finally, run the following to have django listen on all interfaces:
 
 ```bash
 python manage.py runserver 0.0.0.0:8000

--- a/src/ipa-tuura/root/settings.py
+++ b/src/ipa-tuura/root/settings.py
@@ -139,10 +139,20 @@ SCIM_SERVICE_PROVIDER = {
     'USER_ADAPTER': 'ipatuura.adapters.SCIMUser',
     'GROUP_MODEL': 'ipatuura.models.Group',
     'GROUP_ADAPTER': 'ipatuura.adapters.SCIMGroup',
+    'SERVICE_PROVIDER_CONFIG_MODEL': 'ipatuura.models.ServiceProviderConfig',
     'USER_FILTER_PARSER': 'ipatuura.utils.SCIMUserFilterQuery',
     'GROUP_FILTER_PARSER': 'ipatuura.utils.SCIMGroupFilterQuery',
-    # TODO: read from keycloak/sssd.conf
-    # WRITABLE_IFACE values: ipa, ldap, ad
+    'DOCUMENTATION_URI': 'https://www.rfc-editor.org/rfc/rfc7644',
+    'AUTHENTICATION_SCHEMES': [
+        {
+            'type': 'httpbasic',
+            'name': 'HTTP Basic',
+            'description': 'Authentication scheme using the HTTP Basic Standard',
+            'specUri': 'http://www.rfc-editor.org/info/rfc2617',
+            'documentationUri': '',
+        },
+    ],
+    # TODO administrative end-point must configure these values:
     'WRITABLE_IFACE': 'ipa',
     'WRITABLE_USER': 'admin',
 }


### PR DESCRIPTION
This commit enables the /ServiceProviderConfig endpoint for GET requests to view additional information about the ipa-tuura supported features.

The endpoint is read only.