### PR TITLE
Add six package to requirements.txt

### DIFF
--- a/src/install/requirements.txt
+++ b/src/install/requirements.txt
@@ -7,3 +7,4 @@ django-scim2
 django-extensions
 django-oauth-toolkit
 python-pam
+six


### PR DESCRIPTION
This commit fixes dependency issue when running unit tests:

ModuleNotFoundError: No module named 'six'

Signed-off-by: Francisco Trivino <ftrivino@redhat.com>