### PR TITLE
SSSDNotFoundException if dbus cannot talk to SSSD

### DIFF
--- a/src/ipa-tuura/ipatuura/sssd.py
+++ b/src/ipa-tuura/ipatuura/sssd.py
@@ -85,9 +85,9 @@ class _SSSD:
                 DBUS_SSSD_NAME, DBUS_SSSD_GROUPS_PATH)
             self._groups_iface = dbus.Interface(
                 self._groups_obj, DBUS_SSSD_GROUPS_IF)
-        except dbus.DBusException as e:
+        except dbus.DBusException:
             # TBD: add some logging
-            raise e
+            raise SSSDNotFoundException
 
     def _get_user_name(self, user_path):
         """


### PR DESCRIPTION
createsuperuser was failing if SSSD was not running.  Since SSSD should not be a requirement to create the superuser account during setup, we want to skip the SSSD check if it's not running.  So if DBus raises ServiceUnknown while trying to connect to SSSD, we skip that by raising User.DoesNotExist Exception.

Signed-off-by: Scott Poore <spoore@redhat.com>