### PR TITLE
[wsgi] Add project path to the sys.path

### DIFF
--- a/src/ipa-tuura/root/wsgi.py
+++ b/src/ipa-tuura/root/wsgi.py
@@ -12,9 +12,12 @@ https://docs.djangoproject.com/en/3.0/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
 from django.core.wsgi import get_wsgi_application
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../root")
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "root.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
When the WSGI server loads, Django needs to import the settings module by using the DJANGO_SETTINGS_MODULE environment variable to locate the appropriate settings module. It must contain the dotted path to the settings module.

This commit is adding the path to the settings module.

Related: https://github.com/freeipa/ipa-tuura/issues/29