### PR TITLE
Add sample virtualhost .conf file for Apache2 on Fedora

### DIFF
--- a/src/conf/ipatuura.conf
+++ b/src/conf/ipatuura.conf
@@ -1,0 +1,19 @@
+<VirtualHost *:443>
+    LogLevel info
+    RewriteCond %{SERVER_PORT}  !^443$$
+
+    <Directory /www/ipa-tuura/src/ipa-tuura/root/>
+        <Files wsgi.py>
+            Require all granted
+        </Files>
+    </Directory>
+
+    WSGIDaemonProcess ipa-tuura python-path=/www/ipa-tuura/src/ipa-tuura/root
+    WSGIProcessGroup ipa-tuura
+    WSGIScriptAlias / /www/ipa-tuura/src/ipa-tuura/root/wsgi.py
+
+    SSLEngine on
+    SSLCertificateFile /etc/pki/tls/certs/apache-selfsigned.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/apache-selfsigned.key
+
+</VirtualHost>


### PR DESCRIPTION
This needs to be used when hosting the project in production with Apache, mod_ssl, and mod_wsgi (enabling SSL).

Self-certificate can be generated with openssl.