### PR TITLE
Fix project settings to allow deployment in production

### DIFF
--- a/src/ipa-tuura/root/settings.py
+++ b/src/ipa-tuura/root/settings.py
@@ -24,10 +24,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '^$z^y$^ndlem@_f1)($_5vye6t!dk#8+8&9=y5*=-r(v465xg+'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '^$z^y$^ndlem@_f1)($_5vye6t!dk#8+8&9=y5*=-r(v465xg+')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
 ALLOWED_HOSTS = ['*']
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
These changes allow the project to be deployed in production by setting two environment variables:

DJANGO_SECRET_KEY and DJANGO_DEBUG.

Defaults are intended for devel deployment. For production, the envvars must be set accordingly:

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Deployment

Fixes: https://github.com/freeipa/ipa-tuura/issues/33