### PR TITLE
chore(GitHubActions): do not run registry interaction when PR is from fork

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -23,6 +23,7 @@ jobs:
     if: github.repository_owner == 'freeipa'
     needs: [pre-commit]
     env:
+      PR_FROM_FORK: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
       IMAGE_REGISTRY_GITHUB: ghcr.io
       IMAGE_REGISTRY_QUAY: quay.io/idmops/ipa-tuura
       IMAGE_TAG: ${{ github.event.number || github.ref_name  }}  # use PR number else ref_name -> branch name
@@ -67,20 +68,24 @@ jobs:
             ./Dockerfile.test
 # yamllint enable rule:line-length
 
-      - name: Push to Repositories
+      - name: Push to Repositories if PR is not from fork
         id: push-to-repo
         uses: redhat-actions/push-to-registry@v2
+        if: github.repository_owner == 'freeipa' && ! env.PR_FROM_FORK
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
 
-      - name: Print image url
+      - name: Print image url if PR is not from fork
+        if: ${{ ! env.PR_FROM_FORK }}
         run: echo "Image pushed to ${{ steps.push-to-repo.outputs.registry-paths }}"
 
   pull-container:
-    name: Pull the ipa-tuura container
+    name: Pull the ipa-tuura container if PR is not from fork
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'freeipa'
+    if: |
+      github.repository_owner == 'freeipa' &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     needs: [build-container]
     env:
       IMAGE_REGISTRY_GITHUB: ghcr.io
@@ -111,11 +116,11 @@ jobs:
 
       - name: Pull the image previously built from GitHub Container registry
         run: |
-          podman  pull ${{ env.IMAGE_REGISTRY_GITHUB }}:${{ env.IMAGE_TAG }}
-          podman  images
+          podman pull ${{ env.IMAGE_REGISTRY_GITHUB }}:${{ env.IMAGE_TAG }}
+          podman images
 
       - name: Pull the image previously built from Quay.io
         if: github.event_name != 'pull_request'
         run: |
-          podman  pull ${{ env.IMAGE_REGISTRY_QUAY }}:${{ env.IMAGE_TAG }}
-          podman  images
+          podman pull ${{ env.IMAGE_REGISTRY_QUAY }}:${{ env.IMAGE_TAG }}
+          podman images


### PR DESCRIPTION
Skip certain GH actions steps for PRs from forks as GITHUB_TOKEN lack several permissions