### PR TITLE
Integration domain: de-duplicate code between AD and LDAP

### DIFF
--- a/src/ipa-tuura/domains/migrations/0001_initial.py
+++ b/src/ipa-tuura/domains/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=80)),
                 ('integration_domain_url', models.CharField(max_length=255)),
-                ('client_id', models.CharField(max_length=20)),
+                ('client_id', models.CharField(max_length=255)),
                 ('client_secret', models.CharField(max_length=20)),
                 ('description', models.TextField(blank=True)),
                 ('id_provider', models.CharField(choices=[('ipa', 'IPA Provider'), ('ad', 'LDAP Active Directory Provider'), ('ldap', 'LDAP Provider')], default='ipa', max_length=5)),

--- a/src/ipa-tuura/domains/migrations/0001_initial.py
+++ b/src/ipa-tuura/domains/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('id_provider', models.CharField(choices=[('ipa', 'IPA Provider'), ('ad', 'LDAP Active Directory Provider'), ('ldap', 'LDAP Provider')], default='ipa', max_length=5)),
                 ('user_extra_attrs', models.CharField(max_length=255)),
                 ('user_object_classes', models.CharField(max_length=255)),
-                ('users_dn', models.CharField(blank=True, max_length=255)),
+                ('users_dn', models.CharField(max_length=255)),
                 ('ldap_tls_cacert', models.CharField(max_length=100)),
             ],
         ),

--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -61,7 +61,7 @@ class Domain(models.Model):
     user_object_classes = models.CharField(max_length=255, blank=True)
 
     # Optional full DN of LDAP tree where users are
-    users_dn = models.CharField(max_length=255, blank=True)
+    users_dn = models.CharField(max_length=255)
 
     # LDAP auth with TLS support, the file path for now
     # TODO: base64 decode CA cert from HTTP request
@@ -82,15 +82,11 @@ class Domain(models.Model):
                 self.user_object_classes = (
                     "inetOrgPerson," "organizationalPerson," "person," "top"
                 )
-            if not self.users_dn:
-                self.users_dn = "ou=people"
 
         elif self.id_provider == "ad":
             if not self.user_object_classes:
                 self.user_object_classes = (
                     "user," "organizationalPerson," "person," "top"
                 )
-            if not self.users_dn:
-                self.users_dn = "CN=Users"
 
         super().save(*args, **kwargs)

--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -41,7 +41,7 @@ class Domain(models.Model):
     integration_domain_url = models.CharField(max_length=255)
 
     # Temporary admin service username
-    client_id = models.CharField(max_length=20)
+    client_id = models.CharField(max_length=255)
 
     # Temporary admin service password
     client_secret = models.CharField(max_length=20)

--- a/src/ipa-tuura/ipatuura/ipa.py
+++ b/src/ipa-tuura/ipatuura/ipa.py
@@ -201,7 +201,6 @@ class LDAP:
         self._dn = None
         self._users_dn = None
         self._ldap_uri = None
-        self._ldap_search_base = None
         self._ldap_user_extra_attrs = None
         self._user_object_classes = None
         # TLS
@@ -223,7 +222,6 @@ class LDAP:
         self._dn = domain.client_id
         self._ldap_uri = domain.integration_domain_url
         self._ldap_user_extra_attrs = domain.user_extra_attrs
-        self._ldap_search_base = "dc=" + suffix[0] + ", dc=" + suffix[1]
         self._ldap_tls_cacert = domain.ldap_tls_cacert
         self._client_id = domain.client_id
         self._client_secret = domain.client_secret
@@ -315,10 +313,9 @@ class LDAP:
         try:
             # AD: cn, LDAP: uid
             self._conn.add_s(
-                "uid={uid},{usersdn},{basedn}".format(
+                "uid={uid},{usersdn}".format(
                     uid=scim_user.obj.username,
-                    usersdn=self._users_dn,
-                    basedn=self._ldap_search_base,
+                    usersdn=self._users_dn
                 ),
                 ldif,
             )
@@ -333,10 +330,9 @@ class LDAP:
 
         :param scim_user: user object conforming to the SCIM User Schema
         """
-        dn = "uid={uid},{usersdn},{basedn}".format(
+        dn = "uid={uid},{usersdn}".format(
             uid=scim_user.obj.username,
-            usersdn=self._users_dn,
-            basedn=self._ldap_search_base,
+            usersdn=self._users_dn
         )
 
         sn = self.encode(scim_user.obj.last_name)
@@ -368,10 +364,9 @@ class LDAP:
         self._bind()
         try:
             self._conn.delete_s(
-                "uid={uid},{usersdn},{basedn}".format(
+                "uid={uid},{usersdn}".format(
                     uid=scim_user.obj.username,
-                    usersdn=self._users_dn,
-                    basedn=self._ldap_search_base,
+                    usersdn=self._users_dn
                 )
             )
         except ldap.LDAPError as e:
@@ -390,7 +385,6 @@ class AD:
         self._dn = None
         self._users_dn = None
         self._ldap_uri = None
-        self._ldap_search_base = None
         self._ldap_user_extra_attrs = None
         self._user_object_classes = None
         # TLS
@@ -412,7 +406,6 @@ class AD:
         self._dn = domain.client_id + "@" + domain.name
         self._ldap_uri = domain.integration_domain_url
         self._ldap_user_extra_attrs = domain.user_extra_attrs
-        self._ldap_search_base = "dc=" + suffix[0] + ", dc=" + suffix[1]
         self._ldap_tls_cacert = domain.ldap_tls_cacert
         self._client_id = domain.client_id
         self._client_secret = domain.client_secret
@@ -503,10 +496,9 @@ class AD:
         try:
             # AD: cn, LDAP: uid
             self._conn.add_s(
-                "cn={cn},{usersdn},{basedn}".format(
+                "cn={cn},{usersdn}".format(
                     cn=scim_user.obj.username,
-                    usersdn=self._users_dn,
-                    basedn=self._ldap_search_base,
+                    usersdn=self._users_dn
                 ),
                 ldif,
             )
@@ -521,10 +513,9 @@ class AD:
 
         :param scim_user: user object conforming to the SCIM User Schema
         """
-        dn = "cn={cn},{usersdn},{basedn}".format(
+        dn = "cn={cn},{usersdn}".format(
             cn=scim_user.obj.username,
-            usersdn=self._users_dn,
-            basedn=self._ldap_search_base,
+            usersdn=self._users_dn
         )
 
         sn = self.encode(scim_user.obj.last_name)
@@ -556,10 +547,9 @@ class AD:
         self._bind()
         try:
             self._conn.delete_s(
-                "cn={uid},{usersdn},{basedn}".format(
+                "cn={uid},{usersdn}".format(
                     uid=scim_user.obj.username,
-                    usersdn=self._users_dn,
-                    basedn=self._ldap_search_base,
+                    usersdn=self._users_dn
                 )
             )
         except ldap.LDAPError as e:


### PR DESCRIPTION
### Integration domain: users_dn is a full DN

The config parameter users_dn is documented as
"Optional full DN of LDAP tree where users are"
but the current implementation is not consistent with the description.

Make this parameter mandatory, and expect it to contain the full
DN of the users tree, for instance:
ou=users,dc=example,dc=com

With this new behavior, no need to build the user dn from
relative dn + suffix.

### Integration domain: de-duplicate code between AD and LDAP

The classes are 95% identical.
The current differences so far:
- the expected naming convention: users in AD are named
cn=<username>,$USER_BASE_DN
while users in LDAP are named
uid=<username>,$USER_BASE_DN

- the bind DN (client_id) used to connect to the remote AD/LDAP
server. For AD the code is using client_id@domain but we can
use a user DN instead.

Introduce a class variable _user_rdn_attr that stores the
RDN attribute used to build a user DN.

### Integration domain: allow 255 chars for client_id

The client_id contains a bind DN and can be longer than 20 chars.