### PR TITLE
Replace django-rest-swagger with drf-yasg

### DIFF
--- a/src/install/requirements.txt
+++ b/src/install/requirements.txt
@@ -15,4 +15,4 @@ djangorestframework
 markdown
 django-filter
 # swagger
-django-rest-swagger
+drf-yasg

--- a/src/ipa-tuura/root/settings.py
+++ b/src/ipa-tuura/root/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'creds',
     'rest_framework',
     'domains',
-    'rest_framework_swagger',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -22,7 +22,7 @@ from django.urls import include, path, re_path
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
-schema_view = get_schema_view(openapi.info(title="Domains API"))
+schema_view = get_schema_view(openapi.Info(title="Domains API"))
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -30,5 +30,6 @@ urlpatterns = [
     path("scim/v2/", include("django_scim.urls")),
     path("creds/", include("creds.urls")),
     path("domains/v1/", include("domains.urls")),
-    re_path("domains/doc", schema_view),
+    re_path("domains/doc", schema_view.with_ui('swagger', cache_timeout=0)),
+    
 ]

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -22,7 +22,8 @@ from django.urls import include, path, re_path
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
-schema_view = get_schema_view(openapi.Info(title="Domains API"))
+schema_view = get_schema_view(openapi.Info(title="Domains API",
+                                           default_version="v1"))
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -19,9 +19,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path, re_path
-from rest_framework_swagger.views import get_swagger_view
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
-schema_view = get_swagger_view(title="Domains API")
+schema_view = get_schema_view(openapi.info(title="Domains API"))
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
django-rest-swagger is deprecated, see issue #49 