### PR TITLE
Domain: act as a singleton class

### DIFF
--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -89,4 +89,8 @@ class Domain(models.Model):
                     "user," "organizationalPerson," "person," "top"
                 )
 
+        # We should only have one domain registered, override primary key
+        # so that the Domain class acts as a singleton
+        self.pk = 1
+
         super().save(*args, **kwargs)

--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -373,6 +373,21 @@ def add_domain(domain):
 
     Supported identity providers: ipa, ldap, and ad.
     """
+
+    # Fail is there's a domain already registered
+    try:
+        sssdconfig = SSSDConfig.SSSDConfig()
+        sssdconfig.import_config()
+        domains = sssdconfig.list_active_domains()
+    except Exception:
+        # SSSD doesn't exist
+        domains = []
+    if len(domains) > 0:
+        raise RuntimeError(
+            "An existing integration domain is already enabled, "
+            "please delete it before adding a new one."
+        )
+
     # IPA: enroll ipa-tuura as an IPA client to the domain
     # LDAP: add default ldap sssd.conf
     if domain["id_provider"] == "ipa":

--- a/src/ipa-tuura/domains/views.py
+++ b/src/ipa-tuura/domains/views.py
@@ -37,6 +37,8 @@ class DomainViewSet(
         serializer.is_valid(raise_exception=True)
         try:
             add_domain(serializer.validated_data)
+        except RuntimeError as e:
+            return Response(str(e), status=status.HTTP_405_METHOD_NOT_ALLOWED)
         except Exception as e:
             raise e
         else:


### PR DESCRIPTION
Override the primary key of the domain to 1 in order to force the DB to save just a single domain. This will raise an error when registering a domain when there's one already registered.

Resolves: #25