### PR TITLE
Move Django database and keytab to volume mountpoint

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -48,6 +48,9 @@ COPY . /www/ipa-tuura
 # Install project dependencies
 RUN pip install -r /www/ipa-tuura/src/install/requirements.txt
 
+# Create data directory (volume mount point)
+RUN mkdir /www/ipa-tuura/data
+
 # packaging up model changes
 WORKDIR /www/ipa-tuura/src/ipa-tuura/
 RUN python3 manage.py makemigrations

--- a/src/ipa-tuura/root/settings.py
+++ b/src/ipa-tuura/root/settings.py
@@ -86,7 +86,7 @@ WSGI_APPLICATION = 'root.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join('/www/ipa-tuura/data', 'db.sqlite3'),
     }
 }
 
@@ -132,7 +132,7 @@ STATIC_URL = '/static/'
 
 # ipa-tuura configuration
 # We assume that an admin keytab is available
-os.environ["KRB5_CLIENT_KTNAME"] = '/var/lib/ipa/ipatuura/service.keytab'
+os.environ["KRB5_CLIENT_KTNAME"] = '/www/ipa-tuura/data/service.keytab'
 
 AUTH_USER_MODEL = 'scim.User'
 

--- a/src/prod/Containerfile
+++ b/src/prod/Containerfile
@@ -39,6 +39,9 @@ RUN mkdir /www
 COPY . /www/ipa-tuura
 RUN pip install -r /www/ipa-tuura/src/install/requirements.txt
 
+# Create data directory (volume mount point)
+RUN mkdir /www/ipa-tuura/data
+
 # Setup ipa-tuura
 RUN echo 'LoadModule wsgi_module modules/mod_wsgi.so' >> /etc/httpd/conf/httpd.conf
 RUN sed -i 's/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = \['"'*'"'\]/g' /www/ipa-tuura/src/ipa-tuura/root/settings.py


### PR DESCRIPTION
Create a mount point for podman volumes in order to preserve database and keytab state after deleting and recreating the container.