### PR TITLE
Fixing realm join input for AD

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -330,8 +330,10 @@ def join_ad_realm(domain):
         logger.info(f"Error realm discover: {proc.stderr}")
         raise Exception("Error realm discover:\n{}".format(proc.stderr))
 
-    args = ["echo", domain["client_secret"], "|", "realm", "join", realm]
-    proc = subprocess.run(args, capture_output=True, text=True)
+    args = ["sudo", "realm", "join", realm]
+    proc = subprocess.run(
+        args, input=domain["client_secret"], capture_output=True, text=True
+    )
     if proc.returncode != 0:
         logger.info(f"Error realm join: {proc.stderr}")
         raise Exception("Error realm join:\n{}".format(proc.stderr))


### PR DESCRIPTION
realm join command was executing an echo without piping the password to the join command. Input is needed here to pass the password to the realm join.

Also added "sudo" from PR#66 if this is accepted beforehand.

Resolves: #68