### PR TITLE
Change ownership of sssd.conf after creation for LDAP domain

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -395,6 +395,7 @@ def config_default_sssd(domain):
 
     with open(cfg, "w") as fd:
         subprocess.run(["sudo", "chmod", "660", cfg])
+        subprocess.run(["sudo", "chown", "root:root", cfg])
         sssdconfig.write(fd)
 
 


### PR DESCRIPTION
SSSD expects sssd.conf's ownership to be `root:root`.