### PR TITLE
Build production-ready image for GitHub Actions

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: build image
+        id: build-image
         run: |
           sudo -E su
           podman build -t ${{ env.IMAGE_REGISTRY_GITHUB }}:${{ env.IMAGE_TAG }} -f Containerfile.test .

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,10 +1,16 @@
-# Podmanfile for building bridge image in development mode, including Swagger.
+# Containerfile to build a Fedora based image in production mode using Apache and WSGI
+# This image is used by GitHub Actions to run Django unit tests
+#
+# You can build the image by running:
+# podman build -f Containerfile.test .
 
 FROM registry.fedoraproject.org/fedora:38
-ENV TZ=Europe/Madrid
 
+ENV TZ=Europe/Madrid
 LABEL org.opencontainers.image.source=https://github.com/freeipa/ipa-tuura
-LABEL org.opencontainers.image.description="Fedora Bridge Development Image"
+
+# Podmanfile for deploying ipa-tuura in production mode, using Apache HTTPS server
+LABEL org.opencontainers.image.description="Fedora based ipa-tuura bridge service image"
 
 # Install system dependencies
 RUN dnf -y update && dnf -y install \
@@ -30,7 +36,7 @@ RUN dnf -y update && dnf -y install \
     unzip \
     && dnf clean all
 
-# Install bridge dependencies
+# Install ipa-tuura dependencies
 RUN dnf -y update && dnf -y install \
     openldap-clients \
     sssd \
@@ -48,27 +54,42 @@ COPY . /www/ipa-tuura
 # Install project dependencies
 RUN pip install -r /www/ipa-tuura/src/install/requirements.txt
 
-# packaging up model changes
+# Install Unit Test Dependencies
+RUN pip install factory_boy coverage
+
+# Packaging up Django model changes
 WORKDIR /www/ipa-tuura/src/ipa-tuura/
 RUN python3 manage.py makemigrations
 RUN python3 manage.py migrate
 
-# ENV
+# Setup Django superuser
 ENV DJANGO_SUPERUSER_PASSWORD Secret123
 ENV DJANGO_SUPERUSER_USERNAME scim
 ENV DJANGO_SUPERUSER_EMAIL scim@ipa.test
-
-# Create user
 RUN python3 manage.py createsuperuser --scim_username scim --noinput
 
-# Configuration
-RUN sed -i 's/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = \['"'*'"'\]/g' root/settings.py
+# Deploy Django with Apache and mod_wsgi
+RUN echo 'LoadModule wsgi_module modules/mod_wsgi.so' >> /etc/httpd/conf/httpd.conf
+RUN sed -i 's/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = \['"'*'"'\]/g' /www/ipa-tuura/src/ipa-tuura/root/settings.py
 
-# Install Unit Test Dependencies
-RUN pip install factory_boy coverage
+# Generate and configure self-signed certificate
+COPY prod/conf/ipa.conf /root
+RUN openssl req -config /root/ipa.conf -newkey rsa -x509 -days 365 -out /etc/pki/tls/certs/apache-selfsigned.crt
+RUN sed -i 's\localhost.crt\apache-selfsigned.crt\g' /etc/httpd/conf.d/ssl.conf
+RUN sed -i 's\localhost.key\apache-selfsigned.key\g' /etc/httpd/conf.d/ssl.conf
 
-# Create and enable bridge service in devel mode (via manage.py HTTP)
-COPY bridge-devel.service /etc/systemd/system/bridge.service
-RUN systemctl enable bridge
+# Deploy Apache virtual host
+COPY prod/conf/ipatuura.conf /etc/httpd/conf.d/ipatuura.conf
+
+# Setup permissions for apache user
+RUN echo 'apache ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/apache
+RUN usermod -a -G root apache
+RUN chmod -R 770 /etc/sssd
+RUN chmod 740 /www/ipa-tuura/src/ipa-tuura/
+RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/
+RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/db.sqlite3
+
+# Enable httpd service
+RUN systemctl enable httpd
 
 CMD [ "/sbin/init" ]

--- a/prod/Containerfile
+++ b/prod/Containerfile
@@ -1,3 +1,4 @@
+# Containerfile to build a UBI9 RHEL based image in production mode using Apache and WSGI
 # You need a Red Hat subscription to build this container image.
 # You can register your host by following this KCS: https://access.redhat.com/solutions/253273
 #
@@ -10,13 +11,12 @@
 FROM registry.access.redhat.com/ubi9:9.2-755
 
 ENV TZ=Europe/Madrid
-
 LABEL org.opencontainers.image.source=https://github.com/freeipa/ipa-tuura
 
 # Podmanfile for deploying ipa-tuura in production mode, using Apache HTTPS server
-LABEL org.opencontainers.image.description="Production-ready ipatuura bridge service"
+LABEL org.opencontainers.image.description="UBI9 RHEL based ipa-tuura bridge service image"
 
-# Install dependencies
+# Install system dependencies
 RUN dnf -y update && dnf -y install \
     dbus-daemon \
     dbus-devel \
@@ -40,7 +40,7 @@ RUN dnf -y update && dnf -y install \
     unzip \
     && dnf clean all
 
-# Install bridge dependencies
+# Install ipa-tuura dependencies
 RUN dnf -y update && dnf -y install \
     openldap-clients \
     sssd \
@@ -58,7 +58,7 @@ COPY . /www/ipa-tuura
 # Install project dependencies
 RUN pip install -r /www/ipa-tuura/src/install/requirements.txt
 
-# Setup Django database
+# Packaging up Django model changes
 WORKDIR /www/ipa-tuura/src/ipa-tuura/
 RUN python3 manage.py makemigrations
 RUN python3 manage.py migrate
@@ -69,7 +69,7 @@ ENV DJANGO_SUPERUSER_USERNAME scim
 ENV DJANGO_SUPERUSER_EMAIL scim@ipa.test
 RUN python3 manage.py createsuperuser --scim_username scim --noinput
 
-# Setup ipa-tuura
+# Deploy Django with Apache and mod_wsgi
 RUN echo 'LoadModule wsgi_module modules/mod_wsgi.so' >> /etc/httpd/conf/httpd.conf
 RUN sed -i 's/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = \['"'*'"'\]/g' /www/ipa-tuura/src/ipa-tuura/root/settings.py
 
@@ -79,7 +79,7 @@ RUN openssl req -config /root/ipa.conf -newkey rsa -x509 -days 365 -out /etc/pki
 RUN sed -i 's\localhost.crt\apache-selfsigned.crt\g' /etc/httpd/conf.d/ssl.conf
 RUN sed -i 's\localhost.key\apache-selfsigned.key\g' /etc/httpd/conf.d/ssl.conf
 
-# Setup Apache virtual host
+# Deploy Apache virtual host
 COPY prod/conf/ipatuura.conf /etc/httpd/conf.d/ipatuura.conf
 
 # Setup permissions for apache user

--- a/src/install/requirements.txt
+++ b/src/install/requirements.txt
@@ -14,5 +14,3 @@ six
 djangorestframework
 markdown
 django-filter
-# swagger
-django-rest-swagger

--- a/src/ipa-tuura/root/settings.py
+++ b/src/ipa-tuura/root/settings.py
@@ -46,7 +46,6 @@ INSTALLED_APPS = [
     'creds',
     'rest_framework',
     'domains',
-    'rest_framework_swagger',
 ]
 
 MIDDLEWARE = [

--- a/src/ipa-tuura/root/urls.py
+++ b/src/ipa-tuura/root/urls.py
@@ -19,14 +19,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path, re_path
-from rest_framework_swagger.views import get_swagger_view
-
-schema_view = get_swagger_view(title="Domains API")
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("scim/v2/", include("django_scim.urls")),
     path("creds/", include("creds.urls")),
     path("domains/v1/", include("domains.urls")),
-    re_path("domains/doc", schema_view),
 ]


### PR DESCRIPTION
This PR is addressing several simplifications:
- Containerfile.test builds production ready image for Fedora. We are not testing devel image anymore.
- Remove REST Swagger as the project is not maintained and it doesn't work in production environment.
- Fix GitHub Action Push Post-Merge.

