### PR TITLE
Domain: skip POST unittest

### DIFF
--- a/src/ipa-tuura/domains/tests/test_views.py
+++ b/src/ipa-tuura/domains/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 import factory
 from django.test import TestCase
 from django.urls import reverse
@@ -21,6 +23,7 @@ class DomainViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(domain.name, str(response.data))
 
+    @skip("https://github.com/freeipa/ipa-tuura/issues/77")
     def test_post(self):
         """POST to create a Domain."""
         data = {


### PR DESCRIPTION
The domain POST unit test triggers actual enrollment with an integration domain. However, the integration domain is not available in GitHub Actions, leading to failures. This commit introduces a temporary skip for the test until a solution is found for running the test in --dry-run mode.

https://github.com/freeipa/ipa-tuura/issues/77