### PR TITLE
Fix interoperability issues between domains and scim apps

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -13,6 +13,7 @@ import ipalib.errors
 import SSSDConfig
 from ipalib import api
 from ipalib.facts import is_ipa_client_configured
+from scim.ipa import IPA
 from scim.models import User
 
 try:
@@ -441,7 +442,6 @@ def add_domain(domain):
 
     Supported identity providers: ipa, ldap, and ad.
     """
-
     # Fail is there's a domain already registered
     try:
         sssdconfig = SSSDConfig.SSSDConfig()
@@ -477,6 +477,10 @@ def add_domain(domain):
     subprocess.run(["sudo", "chmod", "600", "/etc/sssd/sssd.conf"])
     restart_sssd()
     subprocess.run(["sudo", "chmod", "660", "/etc/sssd/sssd.conf"])
+
+    # reset the writable interface
+    ipa = IPA()
+    ipa._reset_instance()
 
 
 def delete_domain(domain):

--- a/src/ipa-tuura/domains/views.py
+++ b/src/ipa-tuura/domains/views.py
@@ -35,6 +35,8 @@ class DomainViewSet(
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        logger.info(f"domain create {serializer.data}")
+
         try:
             add_domain(serializer.validated_data)
         except RuntimeError as e:


### PR DESCRIPTION
The domains app serves as an administrative interface, facilitating the addition and removal of integration domains. On the other hand, the SCIM app is responsible for handling read and write operations to and from the integration domain. The writability of the interface depends on specific settings within the integration domain.

This commit fixes interoperability issues by introducing a reset method for the writable interface. With this implementation, the object is reset after the addition of a new integration domain, ensuring proper synchronization and functionality.

Fixes: https://github.com/freeipa/ipa-tuura/issues/82