### PR TITLE
Fix race condition when resetting ipa-writable instance

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -13,7 +13,6 @@ import ipalib.errors
 import SSSDConfig
 from ipalib import api
 from ipalib.facts import is_ipa_client_configured
-from scim.ipa import IPA
 from scim.models import User
 
 try:
@@ -477,10 +476,6 @@ def add_domain(domain):
     subprocess.run(["sudo", "chmod", "600", "/etc/sssd/sssd.conf"])
     restart_sssd()
     subprocess.run(["sudo", "chmod", "660", "/etc/sssd/sssd.conf"])
-
-    # reset the writable interface
-    ipa = IPA()
-    ipa._reset_instance()
 
 
 def delete_domain(domain):

--- a/src/ipa-tuura/domains/views.py
+++ b/src/ipa-tuura/domains/views.py
@@ -17,6 +17,7 @@ from rest_framework.mixins import (
 )
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
+from scim.ipa import IPA
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class DomainViewSet(
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        logger.info(f"domain create {serializer.data}")
+        logger.info(f"domain create {serializer.validated_data}")
 
         try:
             add_domain(serializer.validated_data)
@@ -45,6 +46,10 @@ class DomainViewSet(
             raise e
         else:
             self.perform_create(serializer)
+
+        # reset the writable interface
+        ipa = IPA()
+        ipa._reset_instance()
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -80,4 +85,5 @@ class DomainViewSet(
             self.perform_destroy(instance)
         except Http404:
             pass
+
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/ipa-tuura/scim/ipa.py
+++ b/src/ipa-tuura/scim/ipa.py
@@ -408,12 +408,14 @@ class _IPA:
         Initialize writable interface
         """
         self._apiconn = self._write(domains.models.Domain.objects.last().id_provider)
+        logger.info(f"Init writable interface {self._apiconn}")
 
     def _reset_instance(self):
         """
         Perform cleanup
         """
         self._instance = None
+        logger.info("Reset writable interface")
         self.__init__()
 
     def _write(self, iface="ipa"):


### PR DESCRIPTION
Commit 8efb132 introduced a regression. This commit fixes a race condition between domains and scim apps.

Fixes: https://github.com/freeipa/ipa-tuura/issues/85