### PR TITLE
Add endpoint for GSSAPI Authentication

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -45,6 +45,11 @@ RUN dnf -y update && dnf -y install \
     realmd \
     freeipa-client \
     oddjob-mkhomedir \
+    mod_auth_gssapi \
+    mod_session \
+    gssproxy \
+    openssh-clients \
+    sshpass \
     && dnf clean all
 
 # Copy the source code
@@ -88,6 +93,13 @@ RUN chmod -R 770 /etc/sssd
 RUN chmod 740 /www/ipa-tuura/src/ipa-tuura/
 RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/
 RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/db.sqlite3
+
+# Setup gssproxy
+COPY prod/conf/gssproxy.conf /etc/gssproxy/80-httpd.conf
+COPY prod/conf/httpd_env.conf /etc/systemd/system/httpd.service.d/env.conf
+RUN mkdir /var/lib/ipatuura
+RUN chmod 770 /var/lib/ipatuura
+RUN systemctl enable gssproxy
 
 # Enable httpd service
 RUN systemctl enable httpd

--- a/prod/Containerfile
+++ b/prod/Containerfile
@@ -49,6 +49,11 @@ RUN dnf -y update && dnf -y install \
     realmd \
     freeipa-client \
     oddjob-mkhomedir \
+    mod_auth_gssapi \
+    mod_session \
+    gssproxy \
+    openssh-clients \
+    sshpass \
     && dnf clean all
 
 # Copy the source code
@@ -89,6 +94,13 @@ RUN chmod -R 770 /etc/sssd
 RUN chmod 740 /www/ipa-tuura/src/ipa-tuura/
 RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/
 RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/db.sqlite3
+
+# Setup gssproxy
+COPY prod/conf/gssproxy.conf /etc/gssproxy/80-httpd.conf
+COPY prod/conf/httpd_env.conf /etc/systemd/system/httpd.service.d/env.conf
+RUN mkdir /var/lib/ipatuura
+RUN chmod 770 /var/lib/ipatuura
+RUN systemctl enable gssproxy
 
 # Enable httpd service
 RUN systemctl enable httpd

--- a/prod/conf/gssproxy.conf
+++ b/prod/conf/gssproxy.conf
@@ -1,0 +1,5 @@
+[service/HTTP]
+  mechs = krb5
+  cred_store = keytab:/var/lib/ipatuura/httpd.keytab
+  cred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U
+  euid = apache

--- a/prod/conf/httpd_env.conf
+++ b/prod/conf/httpd_env.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=GSS_USE_PROXY=1

--- a/prod/conf/ipatuura.conf
+++ b/prod/conf/ipatuura.conf
@@ -2,6 +2,20 @@
     LogLevel info
     RewriteCond %{SERVER_PORT}  !^443$$
 
+    # Skip mod_wsgi handling for GSSAPI auth endpoint
+    Alias /bridge/login_kerberos/ /dev/null
+    <Location /bridge/login_kerberos/>
+        AuthType GSSAPI
+        AuthName "Kerberos Login"
+        GssapiUseSessions On
+        Session On
+        SessionCookieName session path=/bridge;httponly;secure;
+        SessionHeader SESSION
+        GssapiSessionKey file:/etc/httpd/alias/session.key
+        Header set Remote-User expr=%{REMOTE_USER}
+        Require valid-user
+    </Location>
+
     <Directory /www/ipa-tuura/src/ipa-tuura/root/>
         <Files wsgi.py>
             Require all granted
@@ -11,6 +25,7 @@
     WSGIDaemonProcess ipa-tuura python-path=/www/ipa-tuura/src/ipa-tuura/root
     WSGIProcessGroup ipa-tuura
     WSGIScriptAlias / /www/ipa-tuura/src/ipa-tuura/root/wsgi.py
+    WSGIPassAuthorization On
 
     SSLEngine on
     SSLCertificateFile /etc/pki/tls/certs/apache-selfsigned.crt

--- a/src/ipa-tuura/domains/adapters.py
+++ b/src/ipa-tuura/domains/adapters.py
@@ -25,4 +25,5 @@ class DomainSerializer(ModelSerializer):
             "user_object_classes",
             "users_dn",
             "ldap_tls_cacert",
+            "keycloak_hostname",
         )

--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -46,6 +46,9 @@ class Domain(models.Model):
     # Temporary admin service password
     client_secret = models.CharField(max_length=20)
 
+    # External hostname for Keycloak host
+    keycloak_hostname = models.CharField(max_length=255, blank=True)
+
     # Identity provider type
     id_provider = models.CharField(
         max_length=5,

--- a/src/ipa-tuura/scim/urls.py
+++ b/src/ipa-tuura/scim/urls.py
@@ -1,8 +1,8 @@
 #
-# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
 #
 
-"""root URL Configuration
+"""Integration Domain URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/3.0/topics/http/urls/
@@ -17,13 +17,19 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import include, path, re_path
+import logging
+
+from django.urls import include, re_path
+from rest_framework.routers import DefaultRouter
+from scim.views import BridgeViewSet
+
+logger = logging.getLogger(__name__)
+
+
+router = DefaultRouter()
+router.register("", BridgeViewSet, "bridge")
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("scim/v2/", include("django_scim.urls")),
-    path("creds/", include("creds.urls")),
-    path("domains/v1/", include("domains.urls")),
-    path("bridge/", include("scim.urls")),
+    # we only need /bridge/login_password
+    re_path("", include(router.urls[:1])),
 ]

--- a/src/ipa-tuura/scim/utils.py
+++ b/src/ipa-tuura/scim/utils.py
@@ -1,9 +1,13 @@
 #
-# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2024  FreeIPA Contributors see COPYING for license
 #
 
+from base64 import b64decode, b64encode
+
+import gssapi
 from django.db import NotSupportedError
 from django_scim.filters import GroupFilterQuery, UserFilterQuery
+from requests.auth import AuthBase
 from scim.models import SSSDGroupToGroupModel, SSSDUserToUserModel
 from scim.sssd import SSSD, SSSDNotFoundException
 
@@ -82,3 +86,74 @@ class SCIMGroupFilterQuery(GroupFilterQuery):
 
         group = SSSDGroupToGroupModel(sssd_if, sssdgroup)
         return [group]
+
+
+class NegotiateAuth(AuthBase):
+    """Negotiate Auth using python GSSAPI"""
+
+    def __init__(self, target_host, ccache_name=None):
+        self.context = None
+        self.target_host = target_host
+        self.ccache_name = ccache_name
+
+    def __call__(self, request):
+        self.initial_step(request)
+        request.register_hook("response", self.handle_response)
+        return request
+
+    def deregister(self, response):
+        response.request.deregister_hook("response", self.handle_response)
+
+    def _get_negotiate_token(self, response):
+        token = None
+        if response is not None:
+            h = response.headers.get("www-authenticate", "")
+            if h.startswith("Negotiate"):
+                val = h[h.find("Negotiate") + len("Negotiate") :].strip()
+                if len(val) > 0:
+                    token = b64decode(val)
+        return token
+
+    def _set_authz_header(self, request, token):
+        request.headers["Authorization"] = "Negotiate {}".format(
+            b64encode(token).decode("utf-8")
+        )
+
+    def initial_step(self, request, response=None):
+        if self.context is None:
+            store = {"ccache": self.ccache_name}
+            creds = gssapi.Credentials(usage="initiate", store=store)
+            name = gssapi.Name(
+                "HTTP@{0}".format(self.target_host),
+                name_type=gssapi.NameType.hostbased_service,
+            )
+            self.context = gssapi.SecurityContext(
+                creds=creds, name=name, usage="initiate"
+            )
+
+        in_token = self._get_negotiate_token(response)
+        out_token = self.context.step(in_token)
+        self._set_authz_header(request, out_token)
+
+    def handle_response(self, response, **kwargs):
+        status = response.status_code
+        if status >= 400 and status != 401:
+            return response
+
+        in_token = self._get_negotiate_token(response)
+        if in_token is not None:
+            out_token = self.context.step(in_token)
+            if self.context.complete:
+                return response
+            elif not out_token:
+                return response
+
+            self._set_authz_header(response.request, out_token)
+            # use response so we can make another request
+            _ = response.content  # pylint: disable=unused-variable
+            response.raw.release_conn()
+            newresp = response.connection.send(response.request, **kwargs)
+            newresp.history.append(response)
+            return self.handle_response(newresp, **kwargs)
+
+        return response

--- a/src/ipa-tuura/scim/views.py
+++ b/src/ipa-tuura/scim/views.py
@@ -1,7 +1,65 @@
 #
-# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+# Copyright (C) 2023  FreeIPA Contributors see COPYING for license
 #
 
-# from django.shortcuts import render
+import socket
 
-# Create your views here.
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+try:
+    from ipalib.install.kinit import kinit_password
+except ImportError:
+    from ipapython.ipautil import kinit_password
+
+import logging
+import os
+import tempfile
+
+import requests
+import SSSDConfig
+from scim.utils import NegotiateAuth
+
+logger = logging.getLogger(__name__)
+
+
+class BridgeViewSet(GenericViewSet):
+    @action(detail=False, methods=["post"])
+    def login_password(self, request):
+        if "user" not in request.POST:
+            return Response("User not specified", status=status.HTTP_400_BAD_REQUEST)
+        if "password" not in request.POST:
+            return Response(
+                "Password not specified", status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            sssdconfig = SSSDConfig.SSSDConfig()
+            sssdconfig.import_config()
+        except Exception as e:
+            logger.info("Unable to read SSSD config")
+            raise e
+
+        ccache_dir = tempfile.mkdtemp(prefix="krbcc")
+        ccache_name = os.path.join(ccache_dir, "ccache")
+
+        user = request.POST["user"]
+        passwd = request.POST["password"]
+
+        try:
+            kinit_password(user, passwd, ccache_name)
+        except RuntimeError as e:
+            raise RuntimeError("Kerberos authentication failed: {}".format(e))
+
+        # We now have a valid ticket, request a session cookie
+        server_hostname = socket.gethostname()
+        r = requests.get(
+            f"https://{server_hostname}/bridge/login_kerberos/",
+            auth=NegotiateAuth(server_hostname, ccache_name),
+            verify=False,  # TODO: proper certificates instead of self-signed
+        )
+        session_cookie = r.cookies.get("session")
+
+        return Response({"session": session_cookie})


### PR DESCRIPTION
Add the `login_kerberos` endpoint for handling GSSAPI authentications. mod_auth_gssapi and gssproxy are included as dependencies. Additional steps are included to the IPA domain addition, such as the addition of the HTTP service and keytab retrieval. Additionally, `login_password` endpoint is provided as well, which requests a ticket using the user and password passed with the client request.