### PR TITLE
Use relative path for Dockerfile instead of static in Konflux config

### DIFF
--- a/.tekton/ipa-tuura-pull-request.yaml
+++ b/.tekton/ipa-tuura-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://github.com/freeipa/ipa-tuura/raw/main/Containerfile.test
+    value: Containerfile.test
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after

--- a/.tekton/ipa-tuura-push.yaml
+++ b/.tekton/ipa-tuura-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://github.com/freeipa/ipa-tuura/raw/main/Containerfile.test
+    value: Containerfile.test
   - name: git-url
     value: '{{source_url}}'
   - name: output-image


### PR DESCRIPTION
We need to use the relative path in order for Konflux to pick up changes to Containerfile from PRs.