### PR TITLE
Containerfile.test: add apache user to SSSD group

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -80,7 +80,7 @@ COPY prod/conf/ipatuura.conf /etc/httpd/conf.d/ipatuura.conf
 
 # Setup permissions for apache user
 RUN echo 'apache ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/apache
-RUN usermod -a -G root apache
+RUN usermod -a -G sssd,root apache
 RUN chmod -R 770 /etc/sssd
 RUN chmod 740 /www/ipa-tuura/src/ipa-tuura/
 RUN chown apache:apache /www/ipa-tuura/src/ipa-tuura/


### PR DESCRIPTION
We previously didn't do this in test image because it was based on Fedora, but since the switch to CentOS it's needed again. This change also makes the testing image equal to the production image, except for the base image being CentOS instead of RHEL.