### PR TITLE
 Containerfile: remove maven system dependency 

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -27,7 +27,6 @@ RUN dnf -y update && dnf -y install \
     glibc \
     httpd \
     krb5-devel \
-    maven \
     mod_ssl \
     mod_wsgi \
     openldap-devel \

--- a/prod/Containerfile
+++ b/prod/Containerfile
@@ -31,7 +31,6 @@ RUN dnf -y update && dnf -y install \
     glibc \
     httpd \
     krb5-devel \
-    maven \
     mod_ssl \
     mod_wsgi \
     openldap-devel \


### PR DESCRIPTION
With this commit, a more recent version of Maven (version 3.8) is installed during the container build process. This version is accessible for C9S as a module, thus this commit enables the Maven 3.8 module stream.