### PR TITLE
Removed 'config_file_version' option from 'sssd.conf'

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -496,7 +496,6 @@ def config_default_sssd(domain):
     sssdconfig.optionxform = str
 
     sssdconfig.add_section("sssd")
-    sssdconfig.set("sssd", "config_file_version", "2")
     sssdconfig.set("sssd", "domains", domainname)
     sssdconfig.set("sssd", "services", "nss, pam, ifp")
     domain_section = "%s/%s" % ("domain", domainname)


### PR DESCRIPTION
This option is obsolete / doesn't have meaning quite some time already. It wasn't required as well.
Starting sssd-2.10 it's removed altogether.