### PR TITLE
Remove use_fully_qualified_names from sssd config

### DIFF
--- a/src/ipa-tuura/domains/utils.py
+++ b/src/ipa-tuura/domains/utils.py
@@ -416,6 +416,10 @@ def join_ad_realm(domain):
     domainconfig.set_option(
         "ldap_user_extra_attrs", ", ".join(user_attrs.union(extra_attrs))
     )
+
+    # Remove use_fully_qualified_names so that AD behavior matches IPA and LDAP
+    domainconfig.remove_option("use_fully_qualified_names")
+
     sssdconfig.save_domain(domainconfig)
     sssdconfig.write()
 
@@ -511,7 +515,6 @@ def config_default_sssd(domain):
     sssdconfig.set(domain_section, "ldap_user_extra_attrs", ldap_user_extra_attrs)
     sssdconfig.set(domain_section, "ldap_default_bind_dn", domain["client_id"])
     sssdconfig.set(domain_section, "ldap_default_authtok", domain["client_secret"])
-    sssdconfig.set(domain_section, "use_fully_qualified_names", "True")
     sssdconfig.set(domain_section, "cache_credentials", "True")
     sssdconfig.set(domain_section, "enumerate", "True")
     sssdconfig.set(domain_section, "timeout", "60")


### PR DESCRIPTION
After a realm join, the sssd.conf by default has this option set to
True.  This causes AD behavior to differ slightly from IPA and LDAP by
requiring AD users be fully qualified with a domain in the username.
Removing the use_fully_qualified_names option sets behavior to match
IPA.

In order to standardize across all DC types, we need to also remove
where the option was set for LDAP.

Resolves: #135