### PR TITLE
Konflux: migrate from buildah 0.2 to 0.3

### DIFF
--- a/.tekton/ipa-tuura-pull-request.yaml
+++ b/.tekton/ipa-tuura-pull-request.yaml
@@ -128,9 +128,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:

--- a/.tekton/ipa-tuura-push.yaml
+++ b/.tekton/ipa-tuura-push.yaml
@@ -125,9 +125,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:


### PR DESCRIPTION
Following steps from: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.3/MIGRATION.md