### PR TITLE
ldap_tls_cacert updates

### DIFF
--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -85,6 +85,9 @@ class Domain(models.Model):
                 self.user_object_classes = (
                     "inetOrgPerson," "organizationalPerson," "person," "top"
                 )
+            # This will be overwritten by AD/IPA providers with realm join
+            if not self.ldap_tls_cacert:
+                self.ldap_tls_cacert = "/etc/openldap/certs/cacert.pem"
 
         elif self.id_provider == "ad":
             if not self.user_object_classes:

--- a/src/ipa-tuura/domains/models.py
+++ b/src/ipa-tuura/domains/models.py
@@ -68,7 +68,7 @@ class Domain(models.Model):
 
     # LDAP auth with TLS support, the file path for now
     # TODO: base64 decode CA cert from HTTP request
-    ldap_tls_cacert = models.CharField(max_length=100)
+    ldap_tls_cacert = models.CharField(max_length=100, blank=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Currently, sending the Add integration request without `ldap_tls_cacert` provided fails:

[root@keycloak ~]# curl -k -X POST "https://bridge.ipa.test/domains/v1/domain/" -H "accept: application/json" -H "Content-Type: application/json" -H "X-CSRFToken: x1yU9RGPKs4mJdWIOzEc7wKbwbnJ0B6iTHuW6ja0gdBpEOBVacK1vIhSSYlfsnRw" -d "{ \"name\": \"ipa.test\", \"description\": \"IPA Integration Domain\", \"integration_domain_url\": \"https://master.ipa.test\", \"client_id\": \"admin\", \"client_secret\": \"Secret123\", \"id_provider\": \"ipa\", \"user_extra_attrs\": \"mail:mail, sn:sn, givenname:givenname\", \"users_dn\": \"ou=people,dc=ipa,dc=test\", \"keycloak_hostname\":\"keycloak.ipa.test\"}"

`{"ldap_tls_cacert":["This field is required."]}`